### PR TITLE
.vscodeディレクトリ配下を無視するよう変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ crashlytics-build.properties
 # Temporary auto-generated Android Assets
 /[Aa]ssets/[Ss]treamingAssets/aa.meta
 /[Aa]ssets/[Ss]treamingAssets/aa/*
+
+# for .vscode
+/.vscode/*


### PR DESCRIPTION
unity上のインスペクタに.vscode周りの設定が生えてうるさいので無視